### PR TITLE
initialization of the EVQE population with more than one circuit layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ QUEASARS change log
 
 Current version: 0.2.0
 
+## Unreleased
+
+### Added
+
+- Add the ability to initialize EVQE individuals with more than one circuit layer ([Issue #26])
+
 ## 0.2.0
 
 - Implement a general algorithm structure for Evolving Ansatz VQE algorithms
@@ -12,3 +18,5 @@ Current version: 0.2.0
 ## 0.1.0
 
 - Initial codeless pypi commit
+
+[Issue #26]: https://github.com/DLR-RB/QUEASARS/issues/26


### PR DESCRIPTION
Initialization with more than one circuit layer, may help by initializing the individuals in more complex states. This can help avoid local minima. Closes #26 